### PR TITLE
Lms fix lms card and remove combine user data and task data()

### DIFF
--- a/src/Components/LMS/CheckTasks.js
+++ b/src/Components/LMS/CheckTasks.js
@@ -87,7 +87,7 @@ class CheckTasks extends React.Component {
 
     let { isChecked, nextButtonHidden, prevButtonHidden } = this.state;
 
-    let { lesson, nextLesson, prevLesson, noOfLessons, nextQuestion, prevQuestion, nextUnit, userProgress, book } = this.props;
+    let { lesson, nextLesson, prevLesson, nextQuestion, prevQuestion, nextUnit, userProgress, book } = this.props;
 
     let { currentUnit, currentUnitObj, currentLesson, currentLessonObj, currentQuestion, currentQuestionObj } = this.props.currentValues
 
@@ -219,12 +219,12 @@ class CheckTasks extends React.Component {
 
 
         <div>Unit: {parseInt(currentUnit, 10)+1} of {book.length}</div>
-        <div>current lesson: {parseInt(currentLesson, 10)+1} of {noOfLessons}</div>
+        <div>current lesson: {parseInt(currentLesson, 10)+1} of {book[currentUnit].lessons.length}</div>
         <div>progress: {parseInt(currentQuestion, 10)+1} of {currentLessonObj.questions.length}</div>
 
           {currentQuestion === "0" ? "please begin the lesson" : ''}
 
-          {parseInt(currentQuestion, 10)+1 === noOfLessons? "You finished the unit" : ''}
+          {parseInt(currentQuestion, 10)+1 === book[currentUnit].lessons.length? "You finished the unit" : ''}
 
         </div>
       )

--- a/src/Components/LMS/Dashboard.js
+++ b/src/Components/LMS/Dashboard.js
@@ -525,19 +525,18 @@ class Dashboard extends React.Component {
 
     if(tasks){
 
-      lmsCards = tasks.map((card, i) => {
-        return <LmsCard
+      lmsCards = tasks.map((card, i) => (
+        <LmsCard
           title={book[i].title}
           description={book[i].description}
           image={book[i].image}
           onClick={this.selectCardOnClick}
-          value={book[i].title}
           active={active === book[i].title ? true : false}
           isCompleted={card.userProgress.isCompleted}
           locked={tasks[i].userProgress.isLocked}
           key={card.id}
         />
-      })
+    ))
     }
 
     if(!this.state.startStudyModal && this.state.readyForRender){

--- a/src/Components/LMS/Dashboard.js
+++ b/src/Components/LMS/Dashboard.js
@@ -308,17 +308,20 @@ class Dashboard extends React.Component {
 
 
 
-  // sets current unit
-  selectCardOnClick(value){
-    let { tasks } = this.props.currentValues;
-    let index;
-    tasks.forEach((task, i) => {
+  // sets current unit in LmsCards
+  selectCardOnClick(argId){
+    let { book, userProgress } = this.props;
+    let userProg = userProgress.currentUser.user_progress;
 
-      if(task.title === value && !task.userProgress.isLocked){
+    let index;
+    book.forEach((unit, i) => {
+
+      // don't allow click if it's locked
+      if(unit.id === argId && !userProg[unit.id].isLocked){
         index = i.toString();
-        this.props.setCurrentValues("active", value);
+        this.props.setCurrentValues("active", argId);
         this.props.setCurrentValues("currentUnit", index);
-        this.props.setCurrentValues("currentUnitObj", task);
+        this.props.setCurrentValues("currentUnitObj", unit);
       }
     })
   }

--- a/src/Components/LMS/Dashboard.js
+++ b/src/Components/LMS/Dashboard.js
@@ -135,14 +135,7 @@ class Dashboard extends React.Component {
 
     this.props.setCurrentValues("tasks", taskArr);
     this.props.setCurrentValues("active", activeUnitName);
-    // this.props.setCurrentValues("currentUnit", currentUnit);
-    // this.props.setCurrentValues("currentUnitName", activeUnitName);
-    // this.props.setCurrentValues("currentUnitId", currentUnitId);
 
-    // this.setState({
-    //   ...this.state,
-    //   readyForRender: true,
-    // });
   }
 
 
@@ -449,7 +442,7 @@ class Dashboard extends React.Component {
     let { userProgress, book } = this.props;
 
 
-    let targetQuestion = parseInt(currentQuestion, 10).toString()
+    let targetQuestion = (parseInt(currentQuestion, 10)+1).toString()
 
 
 
@@ -468,9 +461,10 @@ class Dashboard extends React.Component {
     // the current questions from redux
     let curQuest = curLesson.questions
 
-
+    console.log("curQuest1", curQuest)
     // 1. put new true questionId value in questions obj
     curQuest[currentQuestionObj.id] = true;
+    console.log("curQuest2", curQuest, currentQuestionObj.id)
 
     // 2. put questions obj in taskObjRedux
     // console.log('questionID', targetQuestion, curQuest, currentQuestionObj)
@@ -478,14 +472,12 @@ class Dashboard extends React.Component {
 
 
     if(currentLessonObj.questions.length - 1 > parseInt(currentQuestion)+1){
-      console.warn("inside first redux set",currentLessonObj.questions.length - 1, parseInt(currentQuestion)+1, book[currentUnit].lessons[currentLesson].questions[targetQuestion])
       this.props.setCurrentValues("currentQuestion", targetQuestion);
       this.props.setCurrentValues("currentQuestionObj", book[currentUnit].lessons[currentLesson].questions[targetQuestion]);
     // handle if this is the last question of lesson && another lesson exists
-    console.warn("is last lesson?", book[currentUnit].lessons.length, parseInt(currentLesson)+1)
+
   } else if (book[currentUnit].lessons.length > parseInt(currentLesson)+1) {
-      console.warn("is last lesson?", book[currentUnit].lessons.length,  parseInt(currentLesson)+1)
-      console.warn("inside second redux set",currentLessonObj.questions.length - 1, parseInt(currentQuestion)+1, currentQuestion, book[currentUnit].lessons[currentLesson].questions[targetQuestion])
+
       this.props.setCurrentValues("currentQuestion", "0");
       this.props.setCurrentValues("currentQuestionObj", book[currentUnit].lessons[parseInt(currentLesson)+1].questions["0"]);
     }
@@ -494,6 +486,7 @@ class Dashboard extends React.Component {
     // 5. dispatch updated obj - format object for server
     let dto = {};
     dto["userProgress"] = taskObjRedux;
+    console.log('dto', dto)
     this.props.putNextQuestion(1, dto)
   }
 
@@ -519,16 +512,9 @@ class Dashboard extends React.Component {
 
   }
 
-  getLengthOfCurrentLessonArray(){
-    let { tasks, currentUnit } = this.props.currentValues;
-    if(currentUnit){
-      return tasks[currentUnit].lessons.length;
-    }
-  }
 
   render() {
 
-    this.getLengthOfCurrentLessonArray()
     let { active, tasks, currentUnit, currentUnitName, currentUnitId, currentLesson,  currentLessonObj, currentQuestion, currentQuestionObj } = this.props.currentValues;
 
 
@@ -571,7 +557,6 @@ class Dashboard extends React.Component {
                 prevLesson={this.prevLesson}
                 nextQuestion={this.nextQuestion}
                 prevQuestion={this.prevQuestion}
-                noOfLessons={this.getLengthOfCurrentLessonArray()}
               /> : 'Select a unit to begin'}
           </div>
         </div>
@@ -617,14 +602,3 @@ const mapDispatchToProps = dispatch => {
 };
 
 export default connect(mapStateToProps, mapDispatchToProps)(Dashboard);
-
-
-// <Dialog open={this.state.startStudyModal}>
-//   <DialogTitle>"Start Studying Now"</DialogTitle>
-//   <DialogContent>
-//     <p>hgjhg</p>
-//   </DialogContent>
-//   <DialogActions>
-
-//   </DialogActions>
-// </Dialog>

--- a/src/Components/LMS/Dashboard.js
+++ b/src/Components/LMS/Dashboard.js
@@ -18,12 +18,10 @@ class Dashboard extends React.Component {
       startStudyModal: true,
     }
     this.selectCardOnClick = this.selectCardOnClick.bind(this)
-    this.combineUserDataAndTaskData = this.combineUserDataAndTaskData.bind(this);
     this.nextLesson = this.nextLesson.bind(this);
     this.prevLesson = this.prevLesson.bind(this);
     this.getActiveUnit = this.getActiveUnit.bind(this);
     this.getActiveLesson = this.getActiveLesson.bind(this);
-    this.getActiveLessonTemp = this.getActiveLessonTemp.bind(this);
     this.getActiveQuestion = this.getActiveQuestion.bind(this);
     this.nextQuestion = this.nextQuestion.bind(this);
     this.prevQuestion = this.prevQuestion.bind(this);
@@ -32,104 +30,15 @@ class Dashboard extends React.Component {
   }
 
 
-
-  // this must update when a unit is finished (not just
-  // initial rendering) - see if this works
   componentDidMount(){
     this.props.getLmsContent();
     this.props.fetchUserProgress();
-  }
-
-
-
-  componentWillReceiveProps(nextProps){
-    console.log("componentWillReceiveProps")
-    if(this.props.book && this.props.book[0] && this.props.book[0].lessons){
-    }
-
-    if(nextProps !== this.props ){
-
-      if(nextProps.book[0] && nextProps.book[0].lessons && nextProps.book[0] !== this.props.book[0]){
-      }
-      if(nextProps.userProgress.currentUser.user_progress !== this.props.userProgress.currentUser.user_progress){
-        // this.combineUserDataAndTaskData(nextProps.userProgress.currentUser.user_progress);
-      }
-    }
   }
 
   handleStartStudy(){
     this.getActiveUnit();
     this.setState({startStudyModal:false})
   }
-
-  combineUserDataAndTaskData(userData){
-    console.log("combineUserDataAndTaskData")
-    let { book } = this.props;
-    let tasks = Object.keys(userData);
-
-    // taskArr combines server data with local data
-    let taskArr = [];
-
-    // find units on react but not in DB. add to tasks arr.
-    // now we can update react and it renders automatically
-    // we must post this to server later
-    book.forEach(card => {
-      if(tasks.indexOf(card.id) === -1){
-        tasks.push(card.id)
-      }
-    })
-
-    // match up server data and local data to make one array
-    // of task objecs which include a "completed" value (boolean)
-    tasks.forEach(task => {
-      book.forEach(card => {
-        if(card.id === task) {
-          let key = card.id;
-          taskArr.push({
-            userProgress: {
-              name: key,
-              isCompleted: userData[task].unitCompleted,
-              isLocked: userData[task].unitLocked,
-              // lessons: userData[task].lessons
-            },
-            title: card.title,
-            description: card.description,
-            image: card.image,
-            active: false,
-            lessons: card.lessons,
-            id: card.id
-          })
-        }
-      })
-    })
-
-
-    let activeUnitName = null;
-    // sets the initial active unit
-    let currentUnit;
-    let currentUnitId;
-
-    for(let i = 1; i < taskArr.length; i++){
-      if(taskArr[i].userProgress.isCompleted === false && taskArr[i-1].userProgress.isCompleted === true){
-        activeUnitName = taskArr[i].title;
-        currentUnitId = taskArr[i].id;
-        currentUnit = i.toString();
-        i = tasks.length;
-        // now lets find the active lesson
-      } else {
-        activeUnitName = taskArr[0].title;
-        currentUnitId = taskArr[0].id;
-        currentUnit = "0";
-      }
-    }
-
-    this.props.setCurrentValues("tasks", taskArr);
-    this.props.setCurrentValues("active", activeUnitName);
-
-  }
-
-
-
 
   // cycle through to find first incomplete unit
   getActiveUnit(){
@@ -238,66 +147,11 @@ class Dashboard extends React.Component {
       }
     }
 
-    console.log("qobj now ", lastTrueQuestion, finalQuestionIndex)
     this.props.setCurrentValues("currentQuestionObj", lastTrueQuestion);
     this.props.setCurrentValues("currentQuestion", finalQuestionIndex)
 
     this.setState({readyForRender: true})
   }
-
-  getActiveLessonTemp(){
-
-    console.log("getActiveLessonTemp")
-    let { currentValues } = this.props;
-    let userProg = this.props.userProgress.currentUser.user_progress;
-
-    // find first incomplete lesson within active unit
-    currentValues.tasks.forEach(task => {
-      let firstIncompleteLesson = null;
-      let firstIncompleteQuestion = null;
-      let i; // lesson index
-      let j; // question index
-      let finalIndexI;
-      let finalIndexJ;
-
-      if(task.title === currentValues.active){
-
-        let lessonsProgress = userProg[task.id].lessons;
-
-        for(i = task.lessons.length - 1; i >=0; i--){
-          let lessonId = task.lessons[i].id;
-          if(!lessonsProgress[lessonId].lessonCompleted) {
-            firstIncompleteLesson = task.lessons[i];
-            finalIndexI = i.toString();
-          }
-
-          let questions = task.lessons[i].questions;
-
-          // find first incomplete question
-          for(j = questions.length-1; j >=0; j--){
-            if(!lessonsProgress[firstIncompleteLesson.id].questions[questions[j].id]){
-              firstIncompleteQuestion = questions[j]
-              finalIndexJ = j.toString()
-            }
-          }
-        }
-
-        this.props.setCurrentValues("active", task.title);
-        this.props.setCurrentValues("currentUnitName", task.title);
-        this.props.setCurrentValues("currentUnitId", task.id);
-        this.props.setCurrentValues("currentUnitObj", task);
-        this.props.setCurrentValues("currentLesson", finalIndexI);
-        this.props.setCurrentValues("currentLessonObj", firstIncompleteLesson);
-        this.props.setCurrentValues("currentLessonName", firstIncompleteLesson.title);
-        this.props.setCurrentValues("currentQuestion", finalIndexJ);
-        this.props.setCurrentValues("currentQuestionName", firstIncompleteQuestion.title);
-        this.props.setCurrentValues("currentQuestionId", firstIncompleteQuestion.id);
-        this.props.setCurrentValues("currentQuestionObj", firstIncompleteQuestion);
-      }
-    })
-  }
-
-
 
   // sets current unit in LmsCards
   selectCardOnClick(argId){
@@ -355,10 +209,6 @@ class Dashboard extends React.Component {
     // may have to cycle through and find next incomplete
     }
   }
-
-
-
-
 
 
   nextLesson(){

--- a/src/Components/LMS/Dashboard.js
+++ b/src/Components/LMS/Dashboard.js
@@ -7,13 +7,15 @@ import LessonContent from './LessonContent';
 import { connect } from 'react-redux';
 import { getLmsContent } from '../../redux/actions/lmsContent';
 import { getUserProgress, nextQuestion } from '../../redux/actions/userProgress';
-import { setCurrentValue } from "../../redux/actions/currentValues"
+import { setCurrentValue } from "../../redux/actions/currentValues";
+import { Button, Dialog, DialogTitle, DialogActions, DialogContent } from 'react-mdl';
 
 class Dashboard extends React.Component {
   constructor(props){
     super(props)
     this.state= {
       readyForRender: false,
+      startStudyModal: true,
     }
     this.selectCardOnClick = this.selectCardOnClick.bind(this)
     this.combineUserDataAndTaskData = this.combineUserDataAndTaskData.bind(this);
@@ -26,6 +28,7 @@ class Dashboard extends React.Component {
     this.nextQuestion = this.nextQuestion.bind(this);
     this.prevQuestion = this.prevQuestion.bind(this);
     this.nextUnit = this.nextUnit.bind(this);
+    this.handleStartStudy = this.handleStartStudy.bind(this);
   }
 
 
@@ -39,17 +42,18 @@ class Dashboard extends React.Component {
 
 
   // updates state.lesson only when necessary
-  componentDidUpdate(prevProps, prevState){
-    let { currentValues } = this.props;
-    if(prevProps.currentValues.tasks !== currentValues.tasks){
-      // this.getActiveLessonTemp();
-      this.getActiveUnit();
-      // this.getActiveLesson();
-    }
-  }
+  // componentDidUpdate(prevProps, prevState){
+  //   let { currentValues } = this.props;
+  //   if(prevProps.currentValues.tasks !== currentValues.tasks){
+  //     // this.getActiveLessonTemp();
+  //
+  //     // this.getActiveLesson();
+  //   }
+  // }
 
 
   componentWillReceiveProps(nextProps){
+    console.log("componentWillReceiveProps")
     if(this.props.book && this.props.book[0] && this.props.book[0].lessons){
     }
 
@@ -61,6 +65,11 @@ class Dashboard extends React.Component {
         this.combineUserDataAndTaskData(nextProps.userProgress.currentUser.user_progress);
       }
     }
+  }
+
+  handleStartStudy(){
+    this.getActiveUnit();
+    this.setState({startStudyModal:false})
   }
 
   combineUserDataAndTaskData(userData){
@@ -109,7 +118,7 @@ class Dashboard extends React.Component {
     // sets the initial active unit
     let currentUnit;
     let currentUnitId;
-    let activeUnitLessons;
+
     for(let i = 1; i < taskArr.length; i++){
       if(taskArr[i].userProgress.isCompleted === false && taskArr[i-1].userProgress.isCompleted === true){
         activeUnitName = taskArr[i].title;
@@ -126,9 +135,9 @@ class Dashboard extends React.Component {
 
     this.props.setCurrentValues("tasks", taskArr);
     this.props.setCurrentValues("active", activeUnitName);
-    this.props.setCurrentValues("currentUnit", currentUnit);
-    this.props.setCurrentValues("currentUnitName", activeUnitName);
-    this.props.setCurrentValues("currentUnitId", currentUnitId);
+    // this.props.setCurrentValues("currentUnit", currentUnit);
+    // this.props.setCurrentValues("currentUnitName", activeUnitName);
+    // this.props.setCurrentValues("currentUnitId", currentUnitId);
 
     // this.setState({
     //   ...this.state,
@@ -169,9 +178,10 @@ class Dashboard extends React.Component {
 
       }
     }
-
+    console.log("unit posting", lastUnlockedUnit, finalUnitIndex)
     this.props.setCurrentValues("currentUnitObj", lastUnlockedUnit);
     this.props.setCurrentValues("currentUnit", finalUnitIndex)
+
     // 2. set the first unit where isCompleted != true to currentActiveUnitObj & currentActiveUnit
     setTimeout(()=>{
       this.getActiveLesson();
@@ -243,6 +253,8 @@ class Dashboard extends React.Component {
         // console.log(lastTrueQuestion, finalQuestionIndex)
       }
     }
+
+    console.log("qobj now ", lastTrueQuestion, finalQuestionIndex)
     this.props.setCurrentValues("currentQuestionObj", lastTrueQuestion);
     this.props.setCurrentValues("currentQuestion", finalQuestionIndex)
 
@@ -542,7 +554,7 @@ class Dashboard extends React.Component {
       })
     }
 
-    if(this.state.readyForRender){
+    if(!this.state.startStudyModal && this.state.readyForRender){
     // if(false){
 
       return(
@@ -565,7 +577,19 @@ class Dashboard extends React.Component {
         </div>
       )
     }
-    return <div>loading...</div>
+    return (<div>
+            <Dialog open={true}>
+              <DialogTitle>Start Learning</DialogTitle>
+              <DialogActions>
+                <button
+                  onClick={this.handleStartStudy}
+                >
+                  BEGIN
+                </button>
+              </DialogActions>
+            </Dialog>
+            </div>
+    )
   }
 }
 
@@ -593,3 +617,14 @@ const mapDispatchToProps = dispatch => {
 };
 
 export default connect(mapStateToProps, mapDispatchToProps)(Dashboard);
+
+
+// <Dialog open={this.state.startStudyModal}>
+//   <DialogTitle>"Start Studying Now"</DialogTitle>
+//   <DialogContent>
+//     <p>hgjhg</p>
+//   </DialogContent>
+//   <DialogActions>
+
+//   </DialogActions>
+// </Dialog>

--- a/src/Components/LMS/Dashboard.js
+++ b/src/Components/LMS/Dashboard.js
@@ -41,16 +41,6 @@ class Dashboard extends React.Component {
   }
 
 
-  // updates state.lesson only when necessary
-  // componentDidUpdate(prevProps, prevState){
-  //   let { currentValues } = this.props;
-  //   if(prevProps.currentValues.tasks !== currentValues.tasks){
-  //     // this.getActiveLessonTemp();
-  //
-  //     // this.getActiveLesson();
-  //   }
-  // }
-
 
   componentWillReceiveProps(nextProps){
     console.log("componentWillReceiveProps")
@@ -62,7 +52,7 @@ class Dashboard extends React.Component {
       if(nextProps.book[0] && nextProps.book[0].lessons && nextProps.book[0] !== this.props.book[0]){
       }
       if(nextProps.userProgress.currentUser.user_progress !== this.props.userProgress.currentUser.user_progress){
-        this.combineUserDataAndTaskData(nextProps.userProgress.currentUser.user_progress);
+        // this.combineUserDataAndTaskData(nextProps.userProgress.currentUser.user_progress);
       }
     }
   }
@@ -174,6 +164,7 @@ class Dashboard extends React.Component {
     console.log("unit posting", lastUnlockedUnit, finalUnitIndex)
     this.props.setCurrentValues("currentUnitObj", lastUnlockedUnit);
     this.props.setCurrentValues("currentUnit", finalUnitIndex)
+    this.props.setCurrentValues("active", lastUnlockedUnit.id);
 
     // 2. set the first unit where isCompleted != true to currentActiveUnitObj & currentActiveUnit
     setTimeout(()=>{
@@ -518,7 +509,7 @@ class Dashboard extends React.Component {
 
   render() {
 
-    let { active, tasks, currentUnit, currentUnitName, currentUnitId, currentLesson,  currentLessonObj, currentQuestion, currentQuestionObj } = this.props.currentValues;
+    let { active, currentUnit, currentUnitName, currentUnitId, currentLesson,  currentLessonObj, currentQuestion, currentQuestionObj } = this.props.currentValues;
 
 
 
@@ -526,9 +517,9 @@ class Dashboard extends React.Component {
 
     let lmsCards = null;
 
-    if(tasks){
+    if(this.state.readyForRender){
 
-      lmsCards = tasks.map((card, i) => (
+      lmsCards = book.map((unit, i) => (
         <LmsCard
           index={i}
           id={book[i].id}
@@ -536,10 +527,8 @@ class Dashboard extends React.Component {
           description={book[i].description}
           image={book[i].image}
           onClick={this.selectCardOnClick}
-          active={active === book[i].title ? true : false}
-          isCompleted={card.userProgress.isCompleted}
-          locked={tasks[i].userProgress.isLocked}
-          key={card.id}
+          active={active === book[i].id ? true : false}
+          key={unit.id}
         />
     ))
     }

--- a/src/Components/LMS/Dashboard.js
+++ b/src/Components/LMS/Dashboard.js
@@ -527,6 +527,8 @@ class Dashboard extends React.Component {
 
       lmsCards = tasks.map((card, i) => (
         <LmsCard
+          index={i}
+          id={book[i].id}
           title={book[i].title}
           description={book[i].description}
           image={book[i].image}

--- a/src/Components/LMS/LessonContent.js
+++ b/src/Components/LMS/LessonContent.js
@@ -14,7 +14,7 @@ class LessonContent extends React.Component {
     switch(contentType) {
 
       case "checkTasks":
-        let { nextUnit, nextLesson, prevLesson, noOfLessons, nextQuestion, prevQuestion } = this.props;
+        let { nextUnit, nextLesson, prevLesson, nextQuestion, prevQuestion } = this.props;
 
         return(
           <div>
@@ -26,7 +26,7 @@ class LessonContent extends React.Component {
               prevLesson={prevLesson}
               nextQuestion={nextQuestion}
               prevQuestion={prevQuestion}
-              noOfLessons={noOfLessons}
+              
             />
           </div>
         )

--- a/src/Components/Reusable/LmsCard.js
+++ b/src/Components/Reusable/LmsCard.js
@@ -3,44 +3,30 @@ import '../../Styles/LmsCardStyles.css'
 import { connect } from 'react-redux';
 
 class LmsCard extends Component {
-    constructor(props){
-      super(props);
-      this.getCurrentCard = this.getCurrentCard.bind(this);
-    }
 
-    getCurrentCard(){
-      let { active, tasks, currentUnit, currentUnitObj, } = this.props.currentValues;
+    render() {
+      let { image, title, description, active, onClick, userProgress, book, id, index} = this.props;
 
-      let { userProgress, book, id, index } = this.props;
+      let { currentUnit, currentUnitObj, } = this.props.currentValues;
 
       let userProg = userProgress.currentUser.user_progress;
 
-      console.log("currentCard", index, id)
-      // cycle through cards to find which one is current
-
-      //set state values for isLocked and isComplete
-    }
-
-    render() {
-      this.getCurrentCard()
-      const { image, title, description, active, isCompleted, onClick, locked } = this.props;
-
         return(
             <div
-              className={!isCompleted ? "LmsCardContainer locked" : "LmsCardContainer unlocked"}
+              className={!userProg[id].unitCompleted ? "LmsCardContainer locked" : "LmsCardContainer unlocked"}
               id={active ? "currentCard" : ""}
               onClick={e => onClick(title)}
             >
-              <div className="lockIcon"><i className="material-icons">{locked ? "lock" : ""}</i></div>
+              <div className="lockIcon"><i className="material-icons">{userProg[id].unitLocked ? "lock" : ""}</i></div>
               <div className="leftSide">
                 <img src={image} className="LmsImage" alt="blah"/>
               </div>
               <div className="rightSide">
                 <div className="titleCheckboxRow">
-                  <div className="lmsTitleSpan"><p className={isCompleted ? "lmsTitle" : "lmsTitle greyText"} id={active ? "currentCard" : ""}>{title}</p></div>
-                  <div className="lmsCheckboxSpan"><i className="material-icons checkBox">{isCompleted ? "check_box" : "visibility"}</i></div>
+                  <div className="lmsTitleSpan"><p className={userProg[id].unitCompleted ? "lmsTitle" : "lmsTitle greyText"} id={active ? "currentCard" : ""}>{title}</p></div>
+                  <div className="lmsCheckboxSpan"><i className="material-icons checkBox">{userProg[id].unitCompleted ? "check_box" : "visibility"}</i></div>
                 </div>
-                <p className={isCompleted ? "lmsDescription" : "lmsDescription greyText"} id={active ? "currentCard" : ""}>{description}</p>
+                <p className={userProg[id].unitCompleted ? "lmsDescription" : "lmsDescription greyText"} id={active ? "currentCard" : ""}>{description}</p>
               </div>
             </div>
         )

--- a/src/Components/Reusable/LmsCard.js
+++ b/src/Components/Reusable/LmsCard.js
@@ -1,5 +1,7 @@
 import React, {Component} from 'react'
 import '../../Styles/LmsCardStyles.css'
+import { connect } from 'react-redux';
+
 class LmsCard extends Component {
     constructor(props){
       super(props);
@@ -7,12 +9,20 @@ class LmsCard extends Component {
     }
 
     getCurrentCard(){
+      let { active, tasks, currentUnit, currentUnitObj, } = this.props.currentValues;
+
+      let { userProgress, book, id, index } = this.props;
+
+      let userProg = userProgress.currentUser.user_progress;
+
+      console.log("currentCard", index, id)
       // cycle through cards to find which one is current
 
       //set state values for isLocked and isComplete
     }
 
     render() {
+      this.getCurrentCard()
       const { image, title, description, active, isCompleted, onClick, locked } = this.props;
 
         return(
@@ -37,4 +47,10 @@ class LmsCard extends Component {
     }
 }
 
-export default LmsCard
+const mapStateToProps = state => ({
+  book: state.lmsContent.book,
+  userProgress: state.userProgress,
+  currentValues: state.currentValues
+})
+
+export default connect(mapStateToProps, null)(LmsCard);

--- a/src/Components/Reusable/LmsCard.js
+++ b/src/Components/Reusable/LmsCard.js
@@ -1,14 +1,25 @@
 import React, {Component} from 'react'
 import '../../Styles/LmsCardStyles.css'
 class LmsCard extends Component {
+    constructor(props){
+      super(props);
+      this.getCurrentCard = this.getCurrentCard.bind(this);
+    }
+
+    getCurrentCard(){
+      // cycle through cards to find which one is current
+
+      //set state values for isLocked and isComplete
+    }
+
     render() {
-      const { image, title, description, active, isCompleted, onClick, value, locked } = this.props;
+      const { image, title, description, active, isCompleted, onClick, locked } = this.props;
 
         return(
             <div
               className={!isCompleted ? "LmsCardContainer locked" : "LmsCardContainer unlocked"}
               id={active ? "currentCard" : ""}
-              onClick={e => onClick(value)}
+              onClick={e => onClick(title)}
             >
               <div className="lockIcon"><i className="material-icons">{locked ? "lock" : ""}</i></div>
               <div className="leftSide">

--- a/src/Components/Reusable/LmsCard.js
+++ b/src/Components/Reusable/LmsCard.js
@@ -15,7 +15,7 @@ class LmsCard extends Component {
             <div
               className={!userProg[id].unitCompleted ? "LmsCardContainer locked" : "LmsCardContainer unlocked"}
               id={active ? "currentCard" : ""}
-              onClick={e => onClick(title)}
+              onClick={e => onClick(id)}
             >
               <div className="lockIcon"><i className="material-icons">{userProg[id].unitLocked ? "lock" : ""}</i></div>
               <div className="leftSide">


### PR DESCRIPTION
The way I initially designed the code was flawed and inefficient. It was calling a function to combine the book and userProgress data sets and doing that O^2 work every time new props came in. I eliminated that function and, in the last few PRs, have broken all of it's functionality into the getActiveUnit, getActiveLesson, and getActiveQuestion methods instead. Those should be called on a very specific basis (sometimes with lifecyle methods.